### PR TITLE
real-life experience: reduce diff noise, do not take state lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - Migration script: do not print any more the count `>>> 1/N`, because each time N changed, this was causing N spurious diffs, hiding the real elements that changed. The `terravalet_output_format` is now 2.
+- Migration script: do not take a lock; it is useless as long as the operations are strictly on a local state file. This speeds up the runtime.
 
 ### New
 

--- a/main.go
+++ b/main.go
@@ -175,7 +175,10 @@ func script(matches map[string]string, statePath string, out io.Writer) error {
 	fmt.Fprintf(out, "# This script will move %d items.\n\n", len(matches))
 	fmt.Fprintf(out, "set -e\n\n")
 
-	cmd := fmt.Sprintf("terraform state mv -state=%s", statePath)
+	// -lock=false greatly speeds up operations when the state has many elements
+	// and is safe as long as we use -state=FILE, since this keeps operations
+	// strictly local, without considering the configured backend.
+	cmd := fmt.Sprintf("terraform state mv -lock=false -state=%s", statePath)
 
 	// Go maps are unordered. We want instead a stable iteration order, to make it
 	// possible to compare scripts.

--- a/testdata/001_synthetic.down.sh
+++ b/testdata/001_synthetic.down.sh
@@ -6,15 +6,15 @@
 
 set -e
 
-terraform state mv -state=local.tfstate \
+terraform state mv -lock=false -state=local.tfstate \
     'aws_batch_compute_environment.concourse_gpu_batch' \
     'module.ci.aws_batch_compute_environment.concourse_gpu_batch'
 
-terraform state mv -state=local.tfstate \
+terraform state mv -lock=false -state=local.tfstate \
     'aws_instance.bar' \
     'module.ci.aws_instance.bar'
 
-terraform state mv -state=local.tfstate \
+terraform state mv -lock=false -state=local.tfstate \
     'aws_instance.foo["cloud"]' \
     'module.ci.aws_instance.foo["cloud"]'
 

--- a/testdata/001_synthetic.up.sh
+++ b/testdata/001_synthetic.up.sh
@@ -6,15 +6,15 @@
 
 set -e
 
-terraform state mv -state=local.tfstate \
+terraform state mv -lock=false -state=local.tfstate \
     'module.ci.aws_batch_compute_environment.concourse_gpu_batch' \
     'aws_batch_compute_environment.concourse_gpu_batch'
 
-terraform state mv -state=local.tfstate \
+terraform state mv -lock=false -state=local.tfstate \
     'module.ci.aws_instance.bar' \
     'aws_instance.bar'
 
-terraform state mv -state=local.tfstate \
+terraform state mv -lock=false -state=local.tfstate \
     'module.ci.aws_instance.foo["cloud"]' \
     'aws_instance.foo["cloud"]'
 


### PR DESCRIPTION
* Do not print anymore the count >>> 1/N.
  * Unfortunately, it turned out that each time N changed (for example when going from dev-USER to prod), this would cause N spurious diffs, hiding the real changes.
  * Accordingly, the terravalet_output_format is now 2

* Migration script: performance: do not take a lock
  * It is useless as long as the operations are strictly on a local state file.