### PR TITLE
introduce subcommands: rename and move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased [v0.4.0] - (2021-XX-XX)
 ### Fixes
+
 ### Breaking changes
+
+- The CLI API has changed; now it must be invoked by specifying the subcommand:
+  ```
+  $ terravalet rename -plan=PLAN -up=UP.sh -down=DOWN.sh
+  ```
+
 ### Changes
 ### New
 
-## Unreleased [v0.3.0] - (2020-12-11)
+## [v0.3.0] - (2020-12-11)
 
 ### New
 

--- a/README.md
+++ b/README.md
@@ -14,30 +14,36 @@ The API can change in breaking ways until we reach v1.0.0
 
 ## Usage
 
-### Collect information
+There are two modes of operation:
+- [Rename resources](#rename-resources-within-the-same-state) within the same state, with optional fuzzy match.
+- [Move resources](#-move-resources-from-one-state-to-another) from one state to another.
+
+### Rename resources within the same state
+
+#### Collect information
 
 ```
 $ cd $ROOT_MODULE_DIR
 $ terraform plan -no-color 2>&1 | tee plan-01.txt
 ```
 
-### Exact match, success
+#### Exact match, success
 
 Take as input the Terraform plan `plan-01.txt` and generate UP and DOWN migration scripts:
 
 ```
-$ terravalet \
+$ terravalet rename\
     -plan plan-01.txt -up 001_TITLE.up.sh -down 001_TITLE.down.sh
 ```
 
 NOTE: It us up to the user to ensure that the migration number is correct with respect to what is already present in the migration directory.
 
-### Exact match, failure
+#### Exact match, failure
 
 Depending on _how_ the elements have been renamed in the Terraform configuration, it is possible that the exact match will fail:
 
 ```
-$ terravalet \
+$ terravalet rename\
     -plan plan-01.txt -up 001_TITLE.up.sh -down 001_TITLE.down.sh
 match_exact:
 unmatched create:
@@ -46,18 +52,22 @@ unmatched destroy:
   aws_route53_record.foo_private
 ```
 
-### Fuzzy match
+#### Fuzzy match
 
 **WARNING** Fuzzy match can make mistakes. It is up to you to validate that the migration makes sense
 
 If exact match failed, it is possible to enable [q-gram distance](https://github.com/dexyk/stringosim) fuzzy matching with the `-fuzzy-match` flag:
 
 ```
-$ terravalet -fuzzy-match \
+$ terravalet rename-fuzzy-match \
     -plan plan-01.txt -up 001_TITLE.up.sh -down 001_TITLE.down.sh
 WARNING fuzzy match enabled. Double-check the following matches:
  9 aws_route53_record.foo_private -> aws_route53_record.private["foo"]
 ```
+
+## Move resources from one state to another
+
+Not yet implemented.
 
 ## Install
 

--- a/main_test.go
+++ b/main_test.go
@@ -66,7 +66,7 @@ func TestSuccess(t *testing.T) {
 			tmpUpPath := tmpDir + "/up"
 			tmpDownPath := tmpDir + "/down"
 
-			args := []string{"-plan", tc.planPath, "-up", tmpUpPath, "-down", tmpDownPath}
+			args := []string{"rename", "-plan", tc.planPath, "-up", tmpUpPath, "-down", tmpDownPath}
 			args = append(args, tc.options...)
 
 			if err := run(args); err != nil {
@@ -134,7 +134,7 @@ unmatched destroy:
 			tmpUpPath := tmpDir + "/up"
 			tmpDownPath := tmpDir + "/down"
 
-			args := []string{"-plan", tc.planPath, "-up", tmpUpPath, "-down", tmpDownPath}
+			args := []string{"rename", "-plan", tc.planPath, "-up", tmpUpPath, "-down", tmpDownPath}
 
 			err = run(args)
 


### PR DESCRIPTION
Up to now, Terravalet was renaming resources within the same state. This PR introduces subcommands, so that we are ready to add move functionalities (moving a resource from one state to another).