### PR TITLE
Add github actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+# based on https://github.com/marco-m/timeit/blob/master/.github/workflows/ci.yml
+
+on: [push]
+name: CI
+jobs:
+  all:
+    strategy:
+      matrix:
+        go-version: [1.17.x]
+        os: [ubuntu-latest]
+        task-version: [v3.7.0]
+        gotestsum-version: [v1.7.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Install Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+    - name: Install task ${{ matrix.task-version }}
+      run: go install github.com/go-task/task/v3/cmd/task@${{ matrix.task-version }}
+    - name: Install gotestsum ${{ matrix.gotestsum-version }}
+      run: go install gotest.tools/gotestsum@${{ matrix.gotestsum-version }}
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        # By default, actions/checkout will persist the GITHUB_TOKEN, so that further
+        # steps in the job can perform authenticated git commands (that is: WRITE to
+        # the repo). Following the Principle of least privilege, we disable this as long
+        # as we don't need it.
+        persist-credentials: false
+    - name: Go lint
+      run: task lint
+    - name: Terravalet tests
+      run: task test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
-- Bump go to latest v1.16
+- Bump go to latest v1.17
 
 ## [v0.6.0] - (2021-08-11)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,6 +7,19 @@ tasks:
 
   default:
     deps: [test]
+  
+  install-deps:
+    desc: Install tool dependencies.
+    deps:
+      - install-lint
+
+  lint:
+    desc: Lint Terravalet
+    deps:
+      - install-deps
+    cmds:
+      # --enable actually adds to the default linters
+      - golangci-lint run --enable gofmt,gocritic  ./...
 
   build:
     desc: Build the terravalet executable
@@ -99,3 +112,16 @@ tasks:
       GOOS: darwin
       GOARCH: amd64
     vars: *build-vars
+  
+  install-lint:
+    desc: low-level for CI optimization only
+    dir: /tmp
+    cmds:
+      - curl -L {{.GOLANGCI_URL}} -o golangci-lint.tar.gz
+      - tar xzf golangci-lint.tar.gz
+      - cp golangci-lint-{{.GOLANGCI_VERSION}}-linux-amd64/golangci-lint {{.BINDIR}}/golangci-lint
+      - rm -r golangci-lint*
+    vars:
+      GOLANGCI_VERSION: 1.42.0
+      BINDIR: '{{default (print .HOME "/go") .GOPATH}}/bin'
+      GOLANGCI_URL: https://github.com/golangci/golangci-lint/releases/download/v{{.GOLANGCI_VERSION}}/golangci-lint-{{.GOLANGCI_VERSION}}-{{OS}}-{{ARCH}}.tar.gz

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pix4d/terravalet
 
-go 1.16
+go 1.17
 
 require (
 	github.com/dexyk/stringosim v0.0.0-20170922105913-9d0b3e91a842


### PR DESCRIPTION
This PR is just a draft.

Terravalet will be soon open-sourced and we expect to have external contributors. This first commit add GitHub Actions to validate PR and a new task `lint` to validate the correctness of the code. 
At the moment there are two types of checks.
1. go linter (ubuntu-latest, go 1.17)
2. terravalet test (ubuntu-latest, go 1.17)

## TODO
- [x] Actions settings setup
- [x]  Test a fork as normal user ( depends on [#26](https://github.com/Pix4D/repo-settings/pull/26) )


Part of: [PCI-1696](https://pix4dbug.atlassian.net/browse/PCI-1696)

## NOTE
Github Actions is errored, that's normal. It will be fixed by #19