### PR TITLE
add pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 # based on https://github.com/marco-m/timeit/blob/master/.github/workflows/ci.yml
 
-on: [push]
+on: [push, pull_request_target]
 name: CI
 jobs:
   all:


### PR DESCRIPTION
Following the documentation at [github](https://github.blog/2020-08-03-github-actions-improvements-for-fork-and-pull-request-workflows/#improvements-for-public-repository-forks) it appears we should add the `pull_request_target` event in order to enable workflow automatically in forked repository. 

### Before
![forked_actions](https://user-images.githubusercontent.com/9631930/130738307-971407a2-318c-4c56-9a0b-a09c5ebdcbad.png)

### After
![actions_after](https://user-images.githubusercontent.com/9631930/130751708-d559e2ef-b746-4a6b-9b78-337912bcf4a4.png)
