### PR TITLE
Pci 2080 fix fuzzy match bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
         go-version: [1.17.x]
         os: [ubuntu-latest]
         task-version: [v3.7.0]
-        gotestsum-version: [v1.7.0]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Install Go ${{ matrix.go-version }}
@@ -18,8 +17,6 @@ jobs:
         go-version: ${{ matrix.go-version }}
     - name: Install task ${{ matrix.task-version }}
       run: go install github.com/go-task/task/v3/cmd/task@${{ matrix.task-version }}
-    - name: Install gotestsum ${{ matrix.gotestsum-version }}
-      run: go install gotest.tools/gotestsum@${{ matrix.gotestsum-version }}
     - name: Checkout code
       uses: actions/checkout@v2
       with:
@@ -28,7 +25,6 @@ jobs:
         # the repo). Following the Principle of least privilege, we disable this as long
         # as we don't need it.
         persist-credentials: false
-    - name: Go lint
-      run: task lint
-    - name: Terravalet tests
-      run: task test
+    - run: task install-deps
+    - run: task lint
+    - run: task test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,7 @@
+# See https://golangci-lint.run/usage/configuration/#config-file
+
+linters:
+  # NOTE: `enable` _adds_ to the default linters!
+  # To see the currently enabled linters, run `golangci-lint linters`
+  enable:
+    - gocritic

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 ### New
 
+## [v0.6.2] - (Unreleased)
+
+### Fixes
+
+- Fixes a test flake due to the use of unsorted set (i.e {abcde} -> {abdcde} or {abdecde} -> {abdcde})
+
 ## [v0.6.1] - (2021-08-24)
 
 ### Changes

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,19 +7,20 @@ tasks:
 
   default:
     deps: [test]
-  
+
   install-deps:
     desc: Install tool dependencies.
-    deps:
-      - install-lint
+    cmds:
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@{{.GOLANGCI_VERSION}}
+      - go install gotest.tools/gotestsum@{{.GOTESTSUM_VERSION}}
+    vars:
+      GOLANGCI_VERSION: v1.42.0
+      GOTESTSUM_VERSION: v1.7.0
 
   lint:
     desc: Lint Terravalet
-    deps:
-      - install-deps
     cmds:
-      # --enable actually adds to the default linters
-      - golangci-lint run --enable gofmt,gocritic  ./...
+      - golangci-lint run ./...
 
   build:
     desc: Build the terravalet executable
@@ -112,16 +113,3 @@ tasks:
       GOOS: darwin
       GOARCH: amd64
     vars: *build-vars
-  
-  install-lint:
-    desc: low-level for CI optimization only
-    dir: /tmp
-    cmds:
-      - curl -L {{.GOLANGCI_URL}} -o golangci-lint.tar.gz
-      - tar xzf golangci-lint.tar.gz
-      - cp golangci-lint-{{.GOLANGCI_VERSION}}-linux-amd64/golangci-lint {{.BINDIR}}/golangci-lint
-      - rm -r golangci-lint*
-    vars:
-      GOLANGCI_VERSION: 1.42.0
-      BINDIR: '{{default (print .HOME "/go") .GOPATH}}/bin'
-      GOLANGCI_URL: https://github.com/golangci/golangci-lint/releases/download/v{{.GOLANGCI_VERSION}}/golangci-lint-{{.GOLANGCI_VERSION}}-{{OS}}-{{ARCH}}.tar.gz

--- a/main_test.go
+++ b/main_test.go
@@ -458,18 +458,34 @@ func TestMatchFuzzyZeroUnmatched(t *testing.T) {
 }
 
 func TestMatchFuzzyError(t *testing.T) {
-	t.Run("ambiguous migration: two different items have the same match", func(t *testing.T) {
-		create := set.NewStringSet(`abcde`, `abdecde`)
-		destroy := set.NewStringSet(`abdcde`, `hfjabd`)
-		wantError := "ambiguous migration: {abcde} -> {abdcde} or {abdecde} -> {abdcde}"
-		_, _, err := matchFuzzy(create, destroy)
-		if err == nil {
-			t.Fatalf("got: no error; want: an ambiguous migration error")
-		}
-		if err.Error() != wantError {
-			t.Fatalf("got: %s; want: %s", err.Error(), wantError)
-		}
-	})
+	create := set.NewStringSet(`abcde`, `abdecde`)
+	destroy := set.NewStringSet(`abdcde`, `hfjabd`)
+	_, _, err := matchFuzzy(create, destroy)
+	if err == nil {
+		t.Fatalf("got: no error; want: an ambiguous migration error")
+	}
+
+	gotMsg := err.Error()
+	var msg string
+
+	want := "ambiguous migration:"
+	if !strings.HasPrefix(gotMsg, want) {
+		msg += fmt.Sprintf("error message does not start with %q\n", want)
+	}
+
+	want = "{abcde} -> {abdcde}"
+	if !strings.Contains(gotMsg, want) {
+		msg += fmt.Sprintf("error message does not contain %q", want)
+	}
+
+	want = "{abdecde} -> {abdcde}"
+	if !strings.Contains(gotMsg, want) {
+		msg += fmt.Sprintf("error message does not contain %q", want)
+	}
+
+	if msg != "" {
+		t.Fatal(msg)
+	}
 }
 
 func TestRunImportSuccess(t *testing.T) {


### PR DESCRIPTION
Bug: set is not ordered and can return different error strings, in different test runs

- commit 1: boyscout: remove empty spaces from Taskfile
- commit 2: boyscout: gotestsum is a dependency that should be installed from Taskfile (fails to run task otherwise); `use task install-deps` in Github Actions instead of installing it separatly
- commit 3: bugfix `set is not ordered and can return different error strings` attempt 1: ugly
- commit 4: bugfix `set is not ordered and can return different error strings` attempt 2: better

will remove commit 3 after I see PR comments. 