### PR TITLE
cmd import: remove the dedicated pkg/import and keep the code in package main

### DIFF
--- a/cmdimport.go
+++ b/cmdimport.go
@@ -1,4 +1,4 @@
-package import_resources
+package main
 
 import (
 	"encoding/json"

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/dexyk/stringosim"
 	"github.com/integrii/flaggy"
-	import_resources "github.com/pix4d/terravalet/pkg/import"
 	"github.com/scylladb/go-set"
 	"github.com/scylladb/go-set/strset"
 )
@@ -290,7 +289,7 @@ func doImport(upPath, downPath, srcPlanPath, resourcesDefinitions string) error 
 	}
 	defer downFile.Close()
 
-	srcAdd, srcRemove, err := import_resources.Import(srcPlanFile, definitionsFile)
+	srcAdd, srcRemove, err := Import(srcPlanFile, definitionsFile)
 	if err != nil {
 		return fmt.Errorf("parse src-plan: %v", err)
 	}


### PR DESCRIPTION
Terravalet has multiple commands, all except "import" in the main package.
This asymmetry was making the overall code not consistent and thus harder to comprehend.

It might be that one day we realize that it makes sense to have packages, but we are not at that level of complexity yet.