### PR TITLE
Minor fixes for tests

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -212,12 +212,12 @@ func runSuccess(t *testing.T, args []string, wantUpPath string, wantDownPath str
 		t.Fatalf("reading tmp down file: %v", err)
 	}
 
-	if diff := cmp.Diff(wantUp, tmpUp); diff != "" {
+	if diff := cmp.Diff(string(wantUp), string(tmpUp)); diff != "" {
 		t.Errorf("\nup script: mismatch (-want +got):\n"+
 			"(want path: %s)\n"+
 			"%s", wantUpPath, diff)
 	}
-	if diff := cmp.Diff(wantDown, tmpDown); diff != "" {
+	if diff := cmp.Diff(string(wantDown), string(tmpDown)); diff != "" {
 		t.Errorf("\ndown script: mismatch (-want +got):\n"+
 			"(want path: %s)\n"+
 			"%s", wantDownPath, diff)

--- a/main_test.go
+++ b/main_test.go
@@ -212,12 +212,12 @@ func runSuccess(t *testing.T, args []string, wantUpPath string, wantDownPath str
 		t.Fatalf("reading tmp down file: %v", err)
 	}
 
-	if diff := cmp.Diff(wantUp, tmpUp, cmpOpt); diff != "" {
+	if diff := cmp.Diff(wantUp, tmpUp, setCmp); diff != "" {
 		t.Errorf("\nup script: mismatch (-want +got):\n"+
 			"(want path: %s)\n"+
 			"%s", wantUpPath, diff)
 	}
-	if diff := cmp.Diff(wantDown, tmpDown, cmpOpt); diff != "" {
+	if diff := cmp.Diff(wantDown, tmpDown, setCmp); diff != "" {
 		t.Errorf("\ndown script: mismatch (-want +got):\n"+
 			"(want path: %s)\n"+
 			"%s", wantDownPath, diff)
@@ -248,7 +248,7 @@ func runFailure(t *testing.T, args []string, wantErr string) {
 }
 
 // Used to compare sets.
-var cmpOpt = cmp.Comparer(func(s1, s2 *strset.Set) bool {
+var setCmp = cmp.Comparer(func(s1, s2 *strset.Set) bool {
 	return s1.IsEqual(s2)
 })
 
@@ -288,10 +288,10 @@ func TestParseSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatalf("\ngot:  %q\nwant: no error", err)
 			}
-			if diff := cmp.Diff(tc.wantCreate, gotCreate, cmpOpt); diff != "" {
+			if diff := cmp.Diff(tc.wantCreate, gotCreate, setCmp); diff != "" {
 				t.Errorf("\ncreate: mismatch (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantDestroy, gotDestroy, cmpOpt); diff != "" {
+			if diff := cmp.Diff(tc.wantDestroy, gotDestroy, setCmp); diff != "" {
 				t.Errorf("\ndestroy: mismatch (-want +got):\n%s", diff)
 			}
 		})
@@ -401,10 +401,10 @@ func TestMatchExactSomeUnmatched(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			matchExact(tc.create, tc.destroy)
 
-			if diff := cmp.Diff(tc.wantCreate, tc.create, cmpOpt); diff != "" {
+			if diff := cmp.Diff(tc.wantCreate, tc.create, setCmp); diff != "" {
 				t.Errorf("\nUnmatched create: (-want +got):\n%s", diff)
 			}
-			if diff := cmp.Diff(tc.wantDestroy, tc.destroy, cmpOpt); diff != "" {
+			if diff := cmp.Diff(tc.wantDestroy, tc.destroy, setCmp); diff != "" {
 				t.Errorf("\nUnmatched destroy (-want +got):\n%s", diff)
 			}
 		})

--- a/main_test.go
+++ b/main_test.go
@@ -212,12 +212,12 @@ func runSuccess(t *testing.T, args []string, wantUpPath string, wantDownPath str
 		t.Fatalf("reading tmp down file: %v", err)
 	}
 
-	if diff := cmp.Diff(wantUp, tmpUp, setCmp); diff != "" {
+	if diff := cmp.Diff(wantUp, tmpUp); diff != "" {
 		t.Errorf("\nup script: mismatch (-want +got):\n"+
 			"(want path: %s)\n"+
 			"%s", wantUpPath, diff)
 	}
-	if diff := cmp.Diff(wantDown, tmpDown, setCmp); diff != "" {
+	if diff := cmp.Diff(wantDown, tmpDown); diff != "" {
 		t.Errorf("\ndown script: mismatch (-want +got):\n"+
 			"(want path: %s)\n"+
 			"%s", wantDownPath, diff)


### PR DESCRIPTION
Better reviewed commit-per-commit

- tests: use better name for compare function
- fix: tests: do not use set compare function when comparing bytes 
  - The result would be the same, since the implementation of Diff would simply never use the compare function, but the code was way confusing.
- fix: tests: when comparing files, print diff in human-readable format, not raw bytes
  - For text files, having a diff of raw bytes doesn't help; having a diff of strings is better :-)
  
Part of PCI-2275