### PR TITLE
unbreak CI: Git tags again

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,42 +44,11 @@ tasks:
   build:
     desc: Build the terravalet executable.
     cmds:
-      - task: check-tags
       - go build -o bin/terravalet -v -ldflags="{{.LDFLAGS}}" .
     vars: &build-vars
       FULL_VERSION:
-        sh: git describe --long --dirty --always
+        sh: git describe --tags --long --dirty --always
       LDFLAGS: -w -s -X main.fullVersion={{.FULL_VERSION}}
-
-  check-tags:
-      # A lightweight tags is listed as "commit" in the output of  "git for-each-ref 'refs/tags".
-      # If we find at least one, we fail the build.
-      # To replace a lightweight tag with an annotated:
-      # 1. Checkout the lightweight tag
-      #     git checkout <tag>
-      # 2. Look up the date and committer
-      #     git log
-      # 3. Replace the lightweight tag with an annotated one, with the same date and author
-      #     GIT_COMMITTER_DATE="2021-01-31 00:00" \
-      #         git tag --force --annotate <tag> -m 'Release <tag>'
-      # 4. If the lightweight tag has also been pushed to the remote, it can become a mess
-      #    quickly, because it will force everybody to be informed and re-fetch the modified
-      #    tags.
-      # 4.1 Force push the rewritten tag
-      #         git push --force origin <tag>
-      # 4.2 Inform everybody who cloned the repo to perform the following:
-      #         git tag -d <tag>
-      #         git fetch origin tag <tag>
-      # 5. Go back to the HEAD of the branch
-      #         git checkout master
-    desc: Check if the repo contains lightweight git tags beginning with "v".
-    cmds:
-      - if test -n "$WRONG_TAGS"; then echo $HEADER; echo "$WRONG_TAGS"; echo $MSG; exit 1; fi
-    env:
-      WRONG_TAGS:
-        sh: "(git for-each-ref 'refs/tags/v*' | fgrep commit) || exit 0"
-      HEADER: "Error: this repo contains the following lightweight git tags beginning with v (so meant to be release tags):"
-      MSG: Release tags should be annotated. Read the Taskfile for how to fix.
 
   #
   # usage: env RELEASE_TAG=v0.1.0 gopass task release

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -93,11 +93,9 @@ tasks:
         --tag {{.RELEASE_TAG}}
         --name terravalet-darwin-amd64.zip
         --file bin/darwin/terravalet-darwin-amd64.zip
-      # We don't push the git tag. Instead, in the web UI, the act of
-      # transitioning the release from draft to published will create the
-      # corresponding tag in the remote repository. This is safer, because it
-      # reduces the situations when one might be tempted to delete a public tag
-      # due to a mistake in the release.
+      # Push the tag.
+      - cmd: git push origin {{.RELEASE_TAG}}
+      # Create a draft release.
       - cmd: |
           echo "Draft release $RELEASE_TAG created successfully."
           echo "Remember to publish it in the GitHub web UI https://github.com/$GITHUB_USER/$GITHUB_REPO/releases"


### PR DESCRIPTION
- build: drink the Kool-Aid and accept lightweight tags
    - There is something I still do not understand with the GitHub release process.
    This commit at least unbreaks the CI.
    I will create a ticket to investigate deeper.
- release: actually push the git tag
    - This can be confusing. At the beginning I thought that this was the problem:
    we were locally making an annotated tag but then the Github release process
    was making a lightweight tag behind our backs (?). This might or might not be
    the case (needs further investigation). What is sure is that I did push the
    v0.7.0 tag and the CI is still failing.
