### PR TITLE
CI: pin all Actions to their SHA (PCI-4628)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,21 @@ jobs:
         task-version: [v3.44.1]
     runs-on: ${{ matrix.os }}
     steps:
-    - name: Install Go ${{ matrix.go-version }}
-      uses: actions/setup-go@v5
-      with:
-        go-version: ${{ matrix.go-version }}
-    - name: Install task ${{ matrix.task-version }}
-      run: go install github.com/go-task/task/v3/cmd/task@${{ matrix.task-version }}
-    - name: Checkout code
-      uses: actions/checkout@v3
-      with:
-        # By default, actions/checkout will persist the GITHUB_TOKEN, so that further
-        # steps in the job can perform authenticated git commands (that is: WRITE to
-        # the repo). Following the Principle of least privilege, we disable this as long
-        # as we don't need it.
-        persist-credentials: false
-    - run: task install:deps
-    - run: task lint
-    - run: task test
-    - run: task build
+      - name: Install Go ${{ matrix.go-version }}
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # ratchet:actions/setup-go@v5
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Install task ${{ matrix.task-version }}
+        run: go install github.com/go-task/task/v3/cmd/task@${{ matrix.task-version }}
+      - name: Checkout code
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
+        with:
+          # By default, actions/checkout will persist the GITHUB_TOKEN, so that further
+          # steps in the job can perform authenticated git commands (that is: WRITE to
+          # the repo). Following the Principle of least privilege, we disable this as long
+          # as we don't need it.
+          persist-credentials: false
+      - run: task install:deps
+      - run: task lint
+      - run: task test
+      - run: task build


### PR DESCRIPTION
Reference: https://pix4dbug.atlassian.net/browse/PCI-4628